### PR TITLE
add more tests

### DIFF
--- a/src/idp.test.ts
+++ b/src/idp.test.ts
@@ -1,7 +1,6 @@
 const idpHost = process.env.FEDCM_IDP_HOST || 'http://idp-1.localhost:8080';
 const clientId = process.env.FEDCM_CLIENT_ID || 'yourClientID'
 const clientOrigin = process.env.FEDCM_CLIENT_ORIGIN || 'http://localhost:7080'
-const accountId = process.env.FEDCM_CLIENT_ID || '123456'
 export const authCookie = process.env.FEDCM_IDP_AUTH_COOKIE || "";
 console.log(`using auth cookie ${authCookie}`)
 
@@ -127,8 +126,13 @@ describe('Identity Provider HTTP API', () => {
     })
 
     describe.skip('TODO: wip identity assertion endpoint', () => {
+    describe('identity assertion endpoint', () => {
       // id_assertion_endpoint | cookies: yes | client_id: yes | origin: yes
       it('should return identity assertion', async () => {
+        const accountsEndpointURL: string = `${idpHost}${idpApiConfig?.accounts_endpoint}`;
+        const responseAccount = await fetch(accountsEndpointURL, withAuthCookie(withSecFetchHeader(baseRequestOptions)));
+        const dataAccount = await responseAccount.json() as IdentityProviderAccountList;
+        const accountId = dataAccount.accounts[0].id
         const idAssertionEndpointURL = `${idpHost}${idpApiConfig.id_assertion_endpoint}`;
         const nonce = Math.floor(Math.random() * 10e10).toString();
         const response = await fetch(idAssertionEndpointURL,

--- a/src/idp.test.ts
+++ b/src/idp.test.ts
@@ -22,6 +22,16 @@ describe('Identity Provider HTTP API', () => {
 
       expect(response.status).toBe(400);
     });
+
+    it('should return a valid provider url that returns a json file', async () => {
+      const response = await fetch(wellKnownUrl, withSecFetchHeader(baseRequestOptions));
+      const wellKnowConfig: IdentityProviderWellKnown = await response.json() as IdentityProviderWellKnown;
+      const fedcmUrl = wellKnowConfig.provider_urls[0]
+      const responseFedcm = await fetch(fedcmUrl, withSecFetchHeader(baseRequestOptions));
+      const t = await responseFedcm.json() // this should throw an error and break the test if no json is returned
+      expect(response.status).toBe(200);
+
+    });
   })
 
   describe('other endpoints', () => {

--- a/src/idp.test.ts
+++ b/src/idp.test.ts
@@ -1,5 +1,5 @@
 const idpHost = process.env.FEDCM_IDP_HOST || 'http://idp-1.localhost:8080';
-const clientId = process.env.FEDCM_CLIENT_ID || 'yourClientId'
+const clientId = process.env.FEDCM_CLIENT_ID || 'yourClientID'
 const clientOrigin = process.env.FEDCM_CLIENT_ORIGIN || 'http://localhost:7080'
 const accountId = process.env.FEDCM_CLIENT_ID || '123456'
 export const authCookie = process.env.FEDCM_IDP_AUTH_COOKIE || "";

--- a/src/idp.test.ts
+++ b/src/idp.test.ts
@@ -79,9 +79,7 @@ describe('Identity Provider HTTP API', () => {
       it('should return no accounts when no cookie is set', async () => {
         const accountsEndpointURL: string = `${idpHost}${idpApiConfig?.accounts_endpoint}`;
         const response = await fetch(accountsEndpointURL, withSecFetchHeader(baseRequestOptions));
-        const data = await response.json() as IdentityProviderAccountList;
-
-        expect(data.accounts.length).toEqual(0);
+        expect(response.status).toBe(401);
       });
 
       it('should return at least one account with valid cookie', async () => {


### PR DESCRIPTION
This add the assertion endpoint test, and another small test to check if the `provider_urls` returned by  the well-known endpoint return valid URLs. 

Now all the fedcm endpoint are tested :tada: !

```
 PASS  src/idp.test.ts
  Identity Provider HTTP API
    the Well-Known file
      ✓ should return a IdentityProviderWellKnown JSON object (66 ms)
      ✓ should return 400 when Sec-Fetch-Dest is not set (5 ms)
      ✓ should return a valid provider url that returns a json file (7 ms)
    other endpoints
      the config file
        ✓ should return config file (18 ms)
        ✓ should return 400 when Sec-Fetch-Dest is not set (7 ms)
      accounts list endpoint
        ✓ should return accounts list (14 ms)
        ✓ should return no accounts when no cookie is set (9 ms)
        ✓ should return at least one account with valid cookie (15 ms)
        ✓ should return 400 when Sec-Fetch-Dest is not set (11 ms)
      client metadata
        ✓ should return client metadata (16 ms)
      identity assertion endpoint
        ✓ should return identity assertion (18 ms)

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
```

close #5 